### PR TITLE
add no_std support for proofs and dataset generation.

### DIFF
--- a/src/proof/mtree.rs
+++ b/src/proof/mtree.rs
@@ -2,7 +2,7 @@ use core::convert::TryInto;
 use core::ops::Deref;
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec, vec::Vec};
 
 use ethereum_types::H256;
 use lazy_static::lazy_static;
@@ -373,7 +373,6 @@ mod tests {
             1, 2, 3, 4, 5, 6, 7, 8, // e
             1, 2, 3, 4, 5, 6, 7, 8, // f
         ];
-        let hashes = Word::from(word).into_h256_array();
-        println!("{:#?}", hashes);
+        let _hashes = Word::from(word).into_h256_array();
     }
 }

--- a/tests/proof.rs
+++ b/tests/proof.rs
@@ -55,7 +55,7 @@ fn proofs() {
     let dataset_path = std::path::PathBuf::from("target/dataset.bin");
     let dataset = if dataset_path.exists() {
         eprintln!("Dataset found at target/dataset.bin");
-        std::fs::File::open("target/dataset.bin").expect("dataset is generated")
+        std::fs::read("target/dataset.bin").expect("dataset is generated")
     } else {
         let full_size = ethash::get_full_size(dag.epoch);
         let mut bytes = vec![0u8; full_size];
@@ -63,7 +63,7 @@ fn proofs() {
         ethash::make_dataset(&mut bytes, &dag.cache);
         std::fs::write("target/dataset.bin", &bytes).unwrap();
         eprintln!("Dataset is ready!");
-        std::fs::File::open("target/dataset.bin").expect("dataset is generated")
+        std::fs::read("target/dataset.bin").expect("dataset is generated")
     };
     let tree = ethash::calc_dataset_merkle_proofs(dag.epoch, &dataset);
     let root = tree.hash();


### PR DESCRIPTION
Full Dataset generation is now supported for `no_std` targets.

tested with:
```
$ cargo test --release --no-default-features --features=withproofs -- --nocapture
```